### PR TITLE
Added Consistency of Capitalization in summary() Output

### DIFF
--- a/dataCompareR/R/out_unifiedOutputGenerator.R
+++ b/dataCompareR/R/out_unifiedOutputGenerator.R
@@ -75,17 +75,17 @@ createTextSummary <- function(x,...) {
   cat(newLine)
   if(x$ncolInAOnly >0) {
     cat(newLine)
-    cat(paste0("Columns only in ", x$datanameA, colon, paste(x$colsInAOnly,collapse = ', '), space))
+    cat(paste0("Columns only in ", x$datanameA, colon, toupper(paste(x$colsInAOnly,collapse = ', ')), space))
   }
   
   if(x$ncolInBOnly >0) {
     cat(newLine)
-    cat(paste0("Columns only in ", x$datanameB, colon, paste(x$colsInBOnly,collapse = ', '), space))
+    cat(paste0("Columns only in ", x$datanameB, colon, toupper(paste(x$colsInBOnly,collapse = ', ')), space))
   }
   
   if(x$ncolInAOnly >0 | x$ncolInBOnly >0) {
     cat(newLine)
-    cat(paste0("Columns in both ", colon, paste(x$colsInBoth,collapse = ', '), space))
+    cat(paste0("Columns in both ", colon, toupper(paste(x$colsInBoth,collapse = ', ')), space))
   }
   
   # A massive if/else here - if there are no matching columns, there's not much point in continuing...

--- a/dataCompareR/tests/testthat/testMakeValidNames.R
+++ b/dataCompareR/tests/testthat/testMakeValidNames.R
@@ -107,16 +107,18 @@ test_that("makeValidNames function in end to end context", {
   bb <- capture.output(summary(b))
   
   expect_equal(aa[34], "No columns match, so no comparison could take place")
-  expect_equal(aa[30], "Columns only in iris: Petal.Length, Petal.Width, Sepal.Length, Sepal.Width, Species  ")
+  # Issue #40: change to consistent capitalization
+  expect_equal(aa[30], paste0("Columns only in iris: ", toupper("Petal.Length, Petal.Width, Sepal.Length, Sepal.Width, Species  ")))
   
   # There appear to be reordering in this column in the devtools::check() run vs testing normally
   # so we'll just look for the titles
   expect_true(grepl(pattern =  "Columns only in iris2", x = aa[31], fixed = TRUE))
-  expect_true(grepl(pattern =  "a_good_one", x = aa[31], fixed = TRUE))
-  expect_true(grepl(pattern =  "and111", x = aa[31], fixed = TRUE))
-  expect_true(grepl(pattern =  "X.___so.so.bad.", x = aa[31], fixed = TRUE))
-  expect_true(grepl(pattern =  "X.__a.horrible.name.", x = aa[31], fixed = TRUE))
-  expect_true(grepl(pattern =  "X.and...another.", x = aa[31], fixed = TRUE))
+  # change these tests to uppercase for consistent capitalization. Issue #40
+  expect_true(grepl(pattern =  toupper("a_good_one"), x = aa[31], fixed = TRUE))
+  expect_true(grepl(pattern =  toupper("and111"), x = aa[31], fixed = TRUE))
+  expect_true(grepl(pattern =  toupper("X.___so.so.bad."), x = aa[31], fixed = TRUE))
+  expect_true(grepl(pattern =  toupper("X.__a.horrible.name."), x = aa[31], fixed = TRUE))
+  expect_true(grepl(pattern =  toupper("X.and...another."), x = aa[31], fixed = TRUE))
   
   expect_true(grepl(pattern =  "Columns with all rows equal", x = bb[48], fixed = TRUE))
   expect_true(grepl(pattern =  "A_GOOD_ONE", x = bb[48], fixed = TRUE))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Capitalized column names of missing columns to match with the case of other column names. Also changed _testMakeNames_ so that it would work with the capitalization fix.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes issue #40 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran existing tests, changing up testMakeNames so that it pass. Also, made sure to manually run the vignette workflow to visually verify it passes (check screenshot). This change does not affect the rest of the workflow other than the output of `summary`. 

## Screenshots (if appropriate):

This is the output of `summary` after my change.
![new_output_summary](https://user-images.githubusercontent.com/3838378/43240651-66e425b4-904c-11e8-943b-a2289056caf1.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
