### PR TITLE
Allows data frames with 0 rows to be compared

### DIFF
--- a/dataCompareR/R/out_printrcompareobject.R
+++ b/dataCompareR/R/out_printrcompareobject.R
@@ -63,8 +63,18 @@ print.dataCompareRobject <- function(x, nVars=5, nObs=5, verbose= FALSE, ...) {
     
   }
   
-  
-  if(length(x$rowMatching$inA[[1]]) == 0 && length(x$rowMatching$inB[[1]]) == 0) {
+  # Catch the case where one or both tables were empty
+  # For the case where we use a match key
+  if (!matchKeyUsed && 
+      ((length(x$rowMatching$inboth) ==1 && x$rowMatching$inboth == 0 && length(x$rowMatching$inA[[1]])== 0)  ||
+    (length(x$rowMatching$inboth) ==1 && x$rowMatching$inboth == 0 && length(x$rowMatching$inB[[1]]) == 0))) {
+    cat(" no rows compared because at least one table has no rows \n")
+  # And for the case where we do use a match key
+  } else if (matchKeyUsed && ((nrow(x$rowMatching$inboth) == 0 && length(x$rowMatching$inA[[1]]) == 0) ||
+                                 (nrow(x$rowMatching$inboth) == 0 && length(x$rowMatching$inB[[1]]) == 0))) {
+    cat(" no rows compared because at least one table has no rows \n")
+  }
+  else if(length(x$rowMatching$inA[[1]]) == 0 && length(x$rowMatching$inB[[1]]) == 0) {
     # All rows
     cat("all rows were compared \n")
   } else {

--- a/dataCompareR/R/out_summaryrcompareobject.R
+++ b/dataCompareR/R/out_summaryrcompareobject.R
@@ -171,10 +171,21 @@ summary.dataCompareRobject <- function(object, mismatchCount = 5, ...){
   noMatchKeys <- length(object$rowMatching$matchKey) + 1
   
   #Number of Rows in Common:
-  if (isNotNull(object$rowMatching$inboth) & is.integer(object$rowMatching$inboth)){
+  
+  # in the case where we have no match key, object$rowMatching$inboth is an integer
+  # need to handle the case where it's 0 differently to where it's populated
+
+  if (isNotNull(object$rowMatching$inboth) && is.numeric(object$rowMatching$inboth) && 
+      length(object$rowMatching$inboth) == 1 && object$rowMatching$inboth == 0 )
+    {
+    ans$nrowCommon  <- 0
+    } 
+  else if (isNotNull(object$rowMatching$inboth) & is.integer(object$rowMatching$inboth))
+    {
     ans$nrowCommon  <- length(object$rowMatching$inboth)
-  }
-  if (isNotNull(object$rowMatching$inboth) & is.data.frame(object$rowMatching$inboth)){
+    } 
+  else if(isNotNull(object$rowMatching$inboth) & is.data.frame(object$rowMatching$inboth))
+    {
     ans$nrowCommon  <- nrow(object$rowMatching$inboth)
   }
   

--- a/dataCompareR/R/pd_matchRows.R
+++ b/dataCompareR/R/pd_matchRows.R
@@ -162,14 +162,26 @@ matchMultiIndex <- function(df_a, df_b, indices)
 matchNoIndex <- function(df_a, df_b)
 {
   if(nrow(df_a)>nrow(df_b)) {
-    df_a_subset <-df_a[1:nrow(df_b),]
+    
+    if(nrow(df_b)==0) {
+      df_a_subset <- df_a[0,]
+    } else {
+      df_a_subset <- df_a[1:nrow(df_b),]
+    }
+    
     df_b_subset <- df_b
     rows_dropped_from_a <- data.frame(indices_removed=(nrow(df_a_subset)+1):nrow(df_a))
     rows_dropped_from_b <- data.frame(indices_removed=integer())
   }
   else if (nrow(df_b)>nrow(df_a)) {
     df_a_subset <- df_a
-    df_b_subset <-df_b[1:nrow(df_a),]
+    
+    if(nrow(df_a)==0) {
+      df_b_subset <-df_b[0,]
+    } else {
+      df_b_subset <-df_b[1:nrow(df_a),]
+    }
+    
     rows_dropped_from_a <- data.frame(indices_removed=integer())
     rows_dropped_from_b <- data.frame(indices_removed=(nrow(df_b_subset)+1):nrow(df_b))
   }

--- a/dataCompareR/R/rc_rCompare.R
+++ b/dataCompareR/R/rc_rCompare.R
@@ -68,6 +68,8 @@ rCompare <- function(dfA,dfB,keys=NA, roundDigits = NA, mismatches = NA,trimChar
 
   # Validate arguments
   validateArguments(matchKey = keys, roundDigits = roundDigits, maxMismatch = mismatches, coerceCols =  trimChars)
+  checkNA(dfA)
+  checkNA(dfB)
   
   # Make syntactically valid names & keys
   dfA <- makeValidNames(dfA)

--- a/dataCompareR/R/rco_createRowMatching.R
+++ b/dataCompareR/R/rco_createRowMatching.R
@@ -42,6 +42,11 @@ createRowMatching <- function(compObj, x, matchKey)
     
     rowMatching$inboth <- seq(1:nrow(x[[1]]))
     
+    # Above is fine for nrow of 1+ but fails when nrow = 0 because
+    # seq(1:0) returns 1,2 (?)
+    # Correct this
+    if(nrow(x[[1]]) == 0) {rowMatching$inboth <- 0}
+    
   } else {
     rowMatching$inboth <- x[[1]][matchKey]
   }

--- a/dataCompareR/R/vd_checkEmpty.R
+++ b/dataCompareR/R/vd_checkEmpty.R
@@ -13,6 +13,8 @@
 
 #' checkEmpty
 #'
+#' Checks if a df is actually a single NA, or has no columns
+#'
 #' @param df a data frame
 #' @return None. Stops if empty.
 #' @examples
@@ -24,12 +26,39 @@ checkEmpty <- function(df) {
   # So this logic ensures we proceed for large data frames without running the is.na
   # step
   
-  
-  if(nrow(df)>1) {
-    return()
-  } else if (nrow(df) ==0 || is.na(df)) {
+  if(is.null(ncol(df)) || is.na(ncol(df)) || ncol(df)==0) {
+    stop("ERROR : One oe more dataframes have no coumns")
+  }
+}
+
+
+
+#' CheckNA 
+#' 
+#' Checks a data frame is NA - if so, stops
+#' 
+#' @param df A (probable) dataframe
+#' 
+#' @return Nothing. Errors is df is NA
+
+checkNA <- function(df) {
+  if(isSingleNA(df)) {
     stop('ERROR : One or more dataframes are empty')
   }
 }
 
 
+#' isSingleNA
+#' 
+#' Boolean function - T if x is a single NA. False otherwise.
+#' 
+#' @param x literally anything
+#' 
+#' @returns boolean
+isSingleNA <- function(x) {
+  if(is.vector(x) && length(x) == 1 && is.na(x)) {
+    TRUE
+  } else {
+    FALSE
+  }
+}

--- a/dataCompareR/tests/testthat/testCheckEmpty.R
+++ b/dataCompareR/tests/testthat/testCheckEmpty.R
@@ -16,7 +16,8 @@
 #
 # checkEmpty checks whether or not the input data frame is empty 
 # and stops with an error if it is
-#
+# Note that by empty, we mean no columns. Data frames with no columns
+# fail, but data frames with columns but no rows pass
 
 # loading testing library
 library(testthat)
@@ -32,12 +33,18 @@ test_that("Empty DFs give errors", {
                         Model = character(),
                         stringsAsFactors = FALSE)
   
+  veryEmptydf <- data.frame()
+  
   # create populated dataframe
   fulldf <- iris
   
-  # get error with one empty df
-  expect_error( checkEmpty(emptydf), "empty", fixed = TRUE )
+  # no error with cols
+  expect_silent( checkEmpty(emptydf))
   
   # get no error with no empty df
   expect_silent(checkEmpty(fulldf))
+  
+  # get error with empty df
+  expect_error(checkEmpty(veryEmptydf))
+  
   })

--- a/dataCompareR/tests/testthat/testCheckNA.R
+++ b/dataCompareR/tests/testthat/testCheckNA.R
@@ -17,8 +17,8 @@ context('checkNA and isSingleNA')
 
 test_that("checks checkNA works as intended", {
  
-  # This function should return TRUE If, and only If, a single NA is passed 
-  # It appears to catch NaN and a list of 1 Na. I can live with this!
+  # This function should error when a single NA, NaN, or a list with one NA is passed 
+  # Everything else should return silently
 
   expect_error(checkNA(NA))
   expect_error(checkNA(NaN))
@@ -36,10 +36,10 @@ test_that("checks checkNA works as intended", {
 
 })
 
-test_that("checks checkNA works as intended", {
+test_that("checks isSingleNA works as intended", {
   
-  # This function should return TRUE If, and only If, a single NA is passed 
-  # It appears to catch NaN too- I can live with this!
+  # This function should return TRUE when a single NA, NaN, or a list with one NA is passed 
+  # Everything else should return FALSE
   
   expect_true(isSingleNA(NA))
   expect_true(isSingleNA(NaN))

--- a/dataCompareR/tests/testthat/testCheckNA.R
+++ b/dataCompareR/tests/testthat/testCheckNA.R
@@ -1,0 +1,59 @@
+# SPDX-Copyright: Copyright (c) Capital One Services, LLC 
+# SPDX-License-Identifier: Apache-2.0 
+# Copyright 2017 Capital One Services, LLC 
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); 
+# you may not use this file except in compliance with the License. 
+#
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+#
+# Unless required by applicable law or agreed to in writing, software distributed 
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied.
+
+library(testthat)
+
+context('checkNA and isSingleNA')
+
+test_that("checks checkNA works as intended", {
+ 
+  # This function should return TRUE If, and only If, a single NA is passed 
+  # It appears to catch NaN and a list of 1 Na. I can live with this!
+
+  expect_error(checkNA(NA))
+  expect_error(checkNA(NaN))
+  expect_error(checkNA(list(a = NA)))
+  
+  # No other errors should ever be raised
+  expect_silent(checkNA(c(NA,NA)))
+  expect_silent(checkNA(c(1,NA)))
+  expect_silent(checkNA(c("A",NA)))
+  expect_silent(checkNA(iris))
+  expect_silent(checkNA(NULL))
+  expect_silent(checkNA(Inf))
+  
+  
+
+})
+
+test_that("checks checkNA works as intended", {
+  
+  # This function should return TRUE If, and only If, a single NA is passed 
+  # It appears to catch NaN too- I can live with this!
+  
+  expect_true(isSingleNA(NA))
+  expect_true(isSingleNA(NaN))
+  expect_true(isSingleNA(list(a = NA)))
+  
+  # No other errors should ever be raised
+  expect_false(isSingleNA(c(NA,NA)))
+  expect_false(isSingleNA(c(1,NA)))
+  expect_false(isSingleNA(c("A",NA)))
+  expect_false(isSingleNA(iris))
+  expect_false(isSingleNA(NULL))
+  expect_false(isSingleNA(Inf))
+  
+})
+
+
+

--- a/dataCompareR/tests/testthat/testCheckPrintObject.R
+++ b/dataCompareR/tests/testthat/testCheckPrintObject.R
@@ -196,3 +196,119 @@ test_that("test print argument validation", {
   expect_error(print(aaa,nObs=-1))
   
 })
+
+
+test_that("test print with two empty data frames", {
+  
+  # We'll use the pressure dataset for comparison
+  
+  # Make a copy of pressure with missing rows
+  df_empty <-  data.frame(ColA = character(),
+                                    ColB = as.Date(character()),
+                                    ColC = character(),
+                                    stringsAsFactors = FALSE)
+  
+  
+  comp1 <- rCompare(df_empty, df_empty)
+  comp2 <- rCompare(df_empty, df_empty,  keys = "ColA")
+  comp3 <- rCompare(df_empty, df_empty, keys = c("ColA","ColB"))
+  comp4 <- rCompare(df_empty, df_empty, keys = c("ColA","ColB","ColC"))
+  
+  
+  text1 <- capture.output(print(comp1))
+  text2 <- capture.output(print(comp2))
+  text3 <- capture.output(print(comp3))
+  text4 <- capture.output(print(comp4))
+  
+  expect_true(length(text1)==2)
+  expect_that(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text1, fixed = TRUE)), is_true())
+  expect_that(any(grepl("No variables match", text1, fixed = TRUE)), is_true())
+  
+  expect_true(length(text2)==2)
+  expect_that(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text2, fixed = TRUE)), is_true())
+  expect_that(any(grepl("No variables match", text2, fixed = TRUE)), is_true())
+  
+  expect_true(length(text3)==2)
+  expect_that(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text3, fixed = TRUE)), is_true())
+  expect_that(any(grepl("No variables match", text3, fixed = TRUE)), is_true())
+  
+  expect_true(length(text4)==2)
+  expect_that(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text4, fixed = TRUE)), is_true())
+  expect_that(any(grepl("No variables match", text4, fixed = TRUE)), is_true())
+  
+})
+
+
+
+
+test_that("test print with one  empty data frames", {
+  
+  # We'll use the pressure dataset for comparison
+  
+  # Make a copy of pressure with missing rows
+  df_empty <-  data.frame(ColA = character(),
+                          ColB = as.Date(character()),
+                          ColC = character(),
+                          stringsAsFactors = FALSE)
+  
+  
+  df_not_empty <- data.frame(ColA = c("A","B"),
+                             ColB = c(Sys.Date(), Sys.Date()),
+                             ColC = c(1,1),
+                         stringsAsFactors = FALSE)
+  
+  
+  comp1 <- rCompare(df_empty, df_not_empty)
+  comp2 <- rCompare(df_empty, df_not_empty,  keys = "ColA")
+  comp3 <- rCompare(df_empty, df_not_empty, keys = c("ColA","ColB"))
+  comp4 <- rCompare(df_empty, df_not_empty, keys = c("ColA","ColB","ColC"))
+  
+  
+  comp5 <- rCompare(df_not_empty, df_empty)
+  comp6 <- rCompare(df_not_empty, df_empty,  keys = "ColA")
+  comp7 <- rCompare(df_not_empty, df_empty, keys = c("ColA","ColB"))
+  comp8 <- rCompare(df_not_empty, df_empty, keys = c("ColA","ColB","ColC"))
+  
+  text1 <- capture.output(print(comp1))
+  text2 <- capture.output(print(comp2))
+  text3 <- capture.output(print(comp3))
+  text4 <- capture.output(print(comp4))
+  
+  text5 <- capture.output(print(comp5))
+  text6 <- capture.output(print(comp6))
+  text7 <- capture.output(print(comp7))
+  text8 <- capture.output(print(comp8))
+  
+  expect_true(length(text1)==2)
+  expect_that(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text1, fixed = TRUE)), is_true())
+  expect_that(any(grepl("No variables match", text1, fixed = TRUE)), is_true())
+  
+  expect_true(length(text2)==2)
+  expect_that(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text2, fixed = TRUE)), is_true())
+  expect_that(any(grepl("No variables match", text2, fixed = TRUE)), is_true())
+  
+  expect_true(length(text3)==2)
+  expect_that(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text3, fixed = TRUE)), is_true())
+  expect_that(any(grepl("No variables match", text3, fixed = TRUE)), is_true())
+  
+  expect_true(length(text4)==2)
+  expect_that(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text4, fixed = TRUE)), is_true())
+  expect_that(any(grepl("No variables match", text4, fixed = TRUE)), is_true())
+  
+  expect_true(length(text5)==2)
+  expect_that(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text5, fixed = TRUE)), is_true())
+  expect_that(any(grepl("No variables match", text5, fixed = TRUE)), is_true())
+  
+  expect_true(length(text6)==2)
+  expect_that(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text6, fixed = TRUE)), is_true())
+  expect_that(any(grepl("No variables match", text6, fixed = TRUE)), is_true())
+  
+  expect_true(length(text7)==2)
+  expect_that(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text7, fixed = TRUE)), is_true())
+  expect_that(any(grepl("No variables match", text7, fixed = TRUE)), is_true())
+  
+  expect_true(length(text8)==2)
+  expect_that(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text8, fixed = TRUE)), is_true())
+  expect_that(any(grepl("No variables match", text8, fixed = TRUE)), is_true())
+  
+  })

--- a/dataCompareR/tests/testthat/testCheckPrintObject.R
+++ b/dataCompareR/tests/testthat/testCheckPrintObject.R
@@ -241,11 +241,10 @@ test_that("test print with two empty data frames", {
 
 
 
-test_that("test print with one  empty data frames", {
+test_that("test print with one empty data frames", {
   
-  # We'll use the pressure dataset for comparison
+  # We'll make two test data frames - one with empty rows, one populated
   
-  # Make a copy of pressure with missing rows
   df_empty <-  data.frame(ColA = character(),
                           ColB = as.Date(character()),
                           ColC = character(),
@@ -258,6 +257,7 @@ test_that("test print with one  empty data frames", {
                          stringsAsFactors = FALSE)
   
   
+  # Run a set of comparisons on them
   comp1 <- rCompare(df_empty, df_not_empty)
   comp2 <- rCompare(df_empty, df_not_empty,  keys = "ColA")
   comp3 <- rCompare(df_empty, df_not_empty, keys = c("ColA","ColB"))

--- a/dataCompareR/tests/testthat/testPrintSummaryRcompareObject.R
+++ b/dataCompareR/tests/testthat/testPrintSummaryRcompareObject.R
@@ -182,3 +182,134 @@ test_that("the number of rows and columns returned are correct", {
 }) 
 
 
+test_that("the output is correct when both dataframes have no columns", {
+  
+
+  df_empty <-  data.frame(ColA = character(),
+                          ColB = as.Date(character()),
+                          ColC = character(),
+                          stringsAsFactors = FALSE)
+  
+  comp1 <- rCompare(df_empty, df_empty)
+  comp2 <- rCompare(df_empty, df_empty,  keys = "ColA")
+  comp3 <- rCompare(df_empty, df_empty, keys = c("ColA","ColB"))
+  comp4 <- rCompare(df_empty, df_empty, keys = c("ColA","ColB","ColC"))
+  
+  
+  text1 <- capture.output(print(summary(comp1)))
+  text2 <- capture.output(print(summary(comp2)))
+  text3 <- capture.output(print(summary(comp3)))
+  text4 <- capture.output(print(summary(comp4)))
+
+    
+  expect_equal(text1[37], "Number of rows dropped from df_empty: 0  ")
+  expect_equal(text1[38], "Number of rows dropped from  df_empty: 0  ")
+  expect_equal(text1[44], "No rows were compared, so no summary can be provided")
+  
+  expect_equal(text2[37], "Number of rows dropped from df_empty: 0  ")
+  expect_equal(text2[38], "Number of rows dropped from  df_empty: 0  ")
+  expect_equal(text2[44], "No rows were compared, so no summary can be provided")
+  
+  expect_equal(text3[37], "Number of rows dropped from df_empty: 0  ")
+  expect_equal(text3[38], "Number of rows dropped from  df_empty: 0  ")
+  expect_equal(text3[44], "No rows were compared, so no summary can be provided")
+  
+  expect_equal(text4[37], "Number of rows dropped from df_empty: 0  ")
+  expect_equal(text4[38], "Number of rows dropped from  df_empty: 0  ")
+  expect_equal(text4[44], "No rows were compared, so no summary can be provided")
+  
+  
+})
+
+
+test_that("the output is correct when one dataframes has no columns", {
+  
+  
+  df_empty <-  data.frame(ColA = character(),
+                          ColB = as.Date(character()),
+                          ColC = character(),
+                          stringsAsFactors = FALSE)
+  
+  df_not_empty <- data.frame(ColA = c("A","B"),
+                             ColB = c(Sys.Date(), Sys.Date()),
+                             ColC = c(1,1),
+                             stringsAsFactors = FALSE)
+  
+  
+  comp1 <- rCompare(df_empty, df_not_empty)
+  comp2 <- rCompare(df_empty, df_not_empty,  keys = "ColA")
+  comp3 <- rCompare(df_empty, df_not_empty, keys = c("ColA","ColB"))
+  comp4 <- rCompare(df_empty, df_not_empty, keys = c("ColA","ColB","ColC"))
+  
+  
+  comp5 <- rCompare(df_not_empty, df_empty)
+  comp6 <- rCompare(df_not_empty, df_empty,  keys = "ColA")
+  comp7 <- rCompare(df_not_empty, df_empty, keys = c("ColA","ColB"))
+  comp8 <- rCompare(df_not_empty, df_empty, keys = c("ColA","ColB","ColC"))
+  
+  
+  
+  text1 <- capture.output(print(summary(comp1)))
+  text2 <- capture.output(print(summary(comp2)))
+  text3 <- capture.output(print(summary(comp3)))
+  text4 <- capture.output(print(summary(comp4)))
+  
+  text5 <- capture.output(print(summary(comp5)))
+  text6 <- capture.output(print(summary(comp6)))
+  text7 <- capture.output(print(summary(comp7)))
+  text8 <- capture.output(print(summary(comp8)))
+  
+  
+  expect_equal(text1[35], "Total number of rows read from df_not_empty: 2    ")
+  expect_equal(text1[36], "Number of rows in common: 0  ")
+  expect_equal(text1[37], "Number of rows dropped from df_empty: 0  ")
+  expect_equal(text1[38], "Number of rows dropped from  df_not_empty: 2  ")
+  expect_equal(text1[44], "No rows were compared, so no summary can be provided")
+  
+  expect_equal(text2[35], "Total number of rows read from df_not_empty: 2    ")
+  expect_equal(text2[36], "Number of rows in common: 0  ")
+  expect_equal(text2[37], "Number of rows dropped from df_empty: 0  ")
+  expect_equal(text2[38], "Number of rows dropped from  df_not_empty: 2  ")
+  expect_equal(text2[44], "No rows were compared, so no summary can be provided")
+  
+  expect_equal(text3[35], "Total number of rows read from df_not_empty: 2    ")
+  expect_equal(text3[36], "Number of rows in common: 0  ")
+  expect_equal(text3[37], "Number of rows dropped from df_empty: 0  ")
+  expect_equal(text3[38], "Number of rows dropped from  df_not_empty: 2  ")
+  expect_equal(text3[44], "No rows were compared, so no summary can be provided")
+  
+  expect_equal(text4[35], "Total number of rows read from df_not_empty: 2    ")
+  expect_equal(text4[36], "Number of rows in common: 0  ")
+  expect_equal(text4[37], "Number of rows dropped from df_empty: 0  ")
+  expect_equal(text4[38], "Number of rows dropped from  df_not_empty: 2  ")
+  expect_equal(text4[44], "No rows were compared, so no summary can be provided")
+  
+  
+  expect_equal(text5[34], "Total number of rows read from df_not_empty: 2  ")
+  expect_equal(text5[36], "Number of rows in common: 0  ")
+  expect_equal(text5[38], "Number of rows dropped from  df_empty: 0  ")
+  expect_equal(text5[37], "Number of rows dropped from df_not_empty: 2  ")
+  expect_equal(text5[44], "No rows were compared, so no summary can be provided")
+  
+  expect_equal(text6[34], "Total number of rows read from df_not_empty: 2  ")
+  expect_equal(text6[36], "Number of rows in common: 0  ")
+  expect_equal(text6[38], "Number of rows dropped from  df_empty: 0  ")
+  expect_equal(text6[37], "Number of rows dropped from df_not_empty: 2  ")
+  expect_equal(text6[44], "No rows were compared, so no summary can be provided")
+  
+  expect_equal(text7[34], "Total number of rows read from df_not_empty: 2  ")
+  expect_equal(text7[36], "Number of rows in common: 0  ")
+  expect_equal(text7[38], "Number of rows dropped from  df_empty: 0  ")
+  expect_equal(text7[37], "Number of rows dropped from df_not_empty: 2  ")
+  expect_equal(text7[44], "No rows were compared, so no summary can be provided")
+  
+  expect_equal(text8[34], "Total number of rows read from df_not_empty: 2  ")
+  expect_equal(text8[36], "Number of rows in common: 0  ")
+  expect_equal(text8[38], "Number of rows dropped from  df_empty: 0  ")
+  expect_equal(text8[37], "Number of rows dropped from df_not_empty: 2  ")
+  expect_equal(text8[44], "No rows were compared, so no summary can be provided")
+  
+})
+
+
+

--- a/dataCompareR/tests/testthat/testPrintSummaryRcompareObject.R
+++ b/dataCompareR/tests/testthat/testPrintSummaryRcompareObject.R
@@ -182,9 +182,9 @@ test_that("the number of rows and columns returned are correct", {
 }) 
 
 
-test_that("the output is correct when both dataframes have no columns", {
+test_that("the output is correct when both dataframes have no rows", {
   
-
+  # create an empty data frame
   df_empty <-  data.frame(ColA = character(),
                           ColB = as.Date(character()),
                           ColC = character(),

--- a/dataCompareR/tests/testthat/testRCompareStructure.R
+++ b/dataCompareR/tests/testthat/testRCompareStructure.R
@@ -59,3 +59,134 @@ test_that("dataCompareR object meets requirements in row matching", {
   
 })
 
+
+test_that("dataCompareR object when both datasets have no rows", {
+  
+  df_empty <-  data.frame(ColA = character(),
+                          ColB = as.Date(character()),
+                          ColC = character(),
+                          stringsAsFactors = FALSE)
+  
+  
+  comp1 <- rCompare(df_empty, df_empty)
+  comp2 <- rCompare(df_empty, df_empty,  keys = "ColA")
+  comp3 <- rCompare(df_empty, df_empty, keys = c("ColA","ColB"))
+  comp4 <- rCompare(df_empty, df_empty, keys = c("ColA","ColB","ColC"))
+
+  # In all cases, cols should match  
+  expect_true(length(comp1$colMatching$inboth)==3)
+  expect_true(length(comp2$colMatching$inboth)==3)
+  expect_true(length(comp3$colMatching$inboth)==3)
+  expect_true(length(comp4$colMatching$inboth)==3)
+  
+  # No matching row - have to live with the fact this is int or data.frame
+  expect_true(comp1$rowMatching$inboth==0)
+  expect_true(nrow(comp2$rowMatching$inboth)==0)
+  expect_true(nrow(comp3$rowMatching$inboth)==0)
+  expect_true(nrow(comp4$rowMatching$inboth)==0)
+  
+  # no entires in the in either inA or inB entries
+  expect_true(length(comp1$rowMatching$inA$indices_removed)==0)
+  expect_true(length(comp2$rowMatching$inA$COLA)==0)
+  expect_true(length(comp3$rowMatching$inA$COLA)==0)
+  expect_true(length(comp3$rowMatching$inA$COLB)==0)
+  expect_true(length(comp4$rowMatching$inA$COLA)==0)
+  expect_true(length(comp4$rowMatching$inA$COLB)==0)
+  expect_true(length(comp4$rowMatching$inA$COLC)==0)
+  
+  expect_true(length(comp1$rowMatching$inB$indices_removed)==0)
+  expect_true(length(comp2$rowMatching$inB$COLA)==0)
+  expect_true(length(comp3$rowMatching$inB$COLA)==0)
+  expect_true(length(comp3$rowMatching$inB$COLB)==0)
+  expect_true(length(comp4$rowMatching$inB$COLA)==0)
+  expect_true(length(comp4$rowMatching$inB$COLB)==0)
+  expect_true(length(comp4$rowMatching$inB$COLC)==0)
+  
+  
+})
+
+
+
+test_that("dataCompareR object when one datasets has no rows", {
+  
+  df_empty <-  data.frame(ColA = character(),
+                          ColB = as.Date(character()),
+                          ColC = character(),
+                          stringsAsFactors = FALSE)
+  
+  df_not_empty <- data.frame(ColA = c("A","B"),
+                             ColB = c(Sys.Date(), Sys.Date()),
+                             ColC = c(1,1),
+                             stringsAsFactors = FALSE)
+  
+  
+  comp1 <- rCompare(df_empty, df_not_empty)
+  comp2 <- rCompare(df_empty, df_not_empty,  keys = "ColA")
+  comp3 <- rCompare(df_empty, df_not_empty, keys = c("ColA","ColB"))
+  comp4 <- rCompare(df_empty, df_not_empty, keys = c("ColA","ColB","ColC"))
+  
+  
+  comp5 <- rCompare(df_not_empty, df_empty)
+  comp6 <- rCompare(df_not_empty, df_empty,  keys = "ColA")
+  comp7 <- rCompare(df_not_empty, df_empty, keys = c("ColA","ColB"))
+  comp8 <- rCompare(df_not_empty, df_empty, keys = c("ColA","ColB","ColC"))
+  
+  # In all cases, cols should match  
+  expect_true(length(comp1$colMatching$inboth)==3)
+  expect_true(length(comp2$colMatching$inboth)==3)
+  expect_true(length(comp3$colMatching$inboth)==3)
+  expect_true(length(comp4$colMatching$inboth)==3)
+  expect_true(length(comp5$colMatching$inboth)==3)
+  expect_true(length(comp6$colMatching$inboth)==3)
+  expect_true(length(comp7$colMatching$inboth)==3)
+  expect_true(length(comp8$colMatching$inboth)==3)
+  
+  # No matching row - have to live with the fact this is int or data.frame
+  expect_true(comp1$rowMatching$inboth==0)
+  expect_true(nrow(comp2$rowMatching$inboth)==0)
+  expect_true(nrow(comp3$rowMatching$inboth)==0)
+  expect_true(nrow(comp4$rowMatching$inboth)==0)
+  expect_true(comp5$rowMatching$inboth==0)
+  expect_true(nrow(comp6$rowMatching$inboth)==0)
+  expect_true(nrow(comp7$rowMatching$inboth)==0)
+  expect_true(nrow(comp8$rowMatching$inboth)==0)
+
+  # in either inA or inB entries are as expected
+  expect_true(length(comp1$rowMatching$inA$indices_removed)==0)
+  expect_true(length(comp1$rowMatching$inB$indices_removed)==2)
+  
+  expect_true(length(comp2$rowMatching$inA$COLA)==0)
+  expect_true(length(comp2$rowMatching$inB$COLA)==2)
+  
+  expect_true(length(comp3$rowMatching$inA$COLA)==0)
+  expect_true(length(comp3$rowMatching$inA$COLB)==0)
+  expect_true(length(comp3$rowMatching$inB$COLA)==2)
+  expect_true(length(comp3$rowMatching$inB$COLB)==2)
+  
+  expect_true(length(comp4$rowMatching$inA$COLA)==0)
+  expect_true(length(comp4$rowMatching$inA$COLB)==0)
+  expect_true(length(comp4$rowMatching$inA$COLC)==0)
+  expect_true(length(comp4$rowMatching$inB$COLA)==2)
+  expect_true(length(comp4$rowMatching$inB$COLB)==2)
+  expect_true(length(comp4$rowMatching$inB$COLC)==2)
+  
+  
+  expect_true(length(comp5$rowMatching$inB$indices_removed)==0)
+  expect_true(length(comp5$rowMatching$inA$indices_removed)==2)
+  
+  expect_true(length(comp6$rowMatching$inB$COLA)==0)
+  expect_true(length(comp6$rowMatching$inA$COLA)==2)
+  
+  expect_true(length(comp7$rowMatching$inB$COLA)==0)
+  expect_true(length(comp7$rowMatching$inB$COLB)==0)
+  expect_true(length(comp7$rowMatching$inA$COLA)==2)
+  expect_true(length(comp7$rowMatching$inA$COLB)==2)
+  
+  expect_true(length(comp8$rowMatching$inB$COLA)==0)
+  expect_true(length(comp8$rowMatching$inB$COLB)==0)
+  expect_true(length(comp8$rowMatching$inB$COLC)==0)
+  expect_true(length(comp8$rowMatching$inA$COLA)==2)
+  expect_true(length(comp8$rowMatching$inA$COLB)==2)
+  expect_true(length(comp8$rowMatching$inA$COLC)==2)
+  
+})

--- a/dataCompareR/tests/testthat/testcreateReportText.R
+++ b/dataCompareR/tests/testthat/testcreateReportText.R
@@ -95,8 +95,8 @@ test_that("check a key based match with 1 matching keys", {
   testKeys <- rCompare(pressure,pressure2, keys = 'temperature')
   
   # Capture the outpts of createReportText as text
-  textNoKeys <- capture.output(createReportText(dataCompareR:::summary.dataCompareRobject(testNoKeys)))
-  textKeys<- capture.output(createReportText(dataCompareR:::summary.dataCompareRobject(testKeys)))
+  textNoKeys <- capture.output(createReportText(summary.dataCompareRobject(testNoKeys)))
+  textKeys<- capture.output(createReportText(summary.dataCompareRobject(testKeys)))
   
   
   expect_that(length(textKeys) != length(textNoKeys), is_true())

--- a/dataCompareR/tests/testthat/testcreateReportText.R
+++ b/dataCompareR/tests/testthat/testcreateReportText.R
@@ -33,8 +33,8 @@ test_that("check a non comprehensive set of properties about createReportText", 
   testDiff <- rCompare(iris,iris2)
   
   # Capture the outpts of createReportText as text
-  textSame <- capture.output(createReportText(dataCompareR:::summary.dataCompareRobject(testSame)))
-  textDiff <- capture.output(createReportText(dataCompareR:::summary.dataCompareRobject(testDiff)))
+  textSame <- capture.output(createReportText(summary.dataCompareRobject(testSame)))
+  textDiff <- capture.output(createReportText(summary.dataCompareRobject(testDiff)))
   
   # For now we won't hard code each - instead, we will just check a few points...
   


### PR DESCRIPTION
## Description

Allow data frames with 0 rows (but >0) columns to be compared as easily as data frames with rows.

## Motivation and Context

#23 - I don't think this was necessarily a bug, rather a poor design choice. This goes some way to making `dataCompareR` more useful inside other code, rather than being limited to a tool for interactive usage. I'd like to tackle #8 in `v1.1.3` to go further in this direction.

## How Has This Been Tested?
It's fair to say that some of the current code/object structure could be better - for example, the `rCompare` object stores matching rows either as indices (for key-less comparison) or as `data.frames` (for key based comparisons), making much code twice as hard.

A few small tweaks were needed to the core comparison code, mainly to handle cases where we'd used `seq(1:n)` which doesn't work as expected (or at least, as I expected) when `n=0`.

The `print` function was tweaked to make the output more clear.

Unit tests have been updated where appropriate, but largely, the existing tests pass unchanged. Numerous new tests were added to check the structure of the comparison object, the print and summary output, for cases when 1 or both data sets have no rows.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
