### PR TITLE
Issue on testthat dependencies

### DIFF
--- a/dataCompareR/tests/testthat/createTitanicDatasets.R
+++ b/dataCompareR/tests/testthat/createTitanicDatasets.R
@@ -37,6 +37,7 @@
 #* Row 8: name in uppercase
 #* Row 9: special characters included
 
+if (!require(titanic)) install.packages("titanic")
 
 #titanicKK <- read.csv('./tests/testthat/titanic_train.csv')
 titanic <- titanic_train

--- a/dataCompareR/tests/testthat/testCheckPrintObject.R
+++ b/dataCompareR/tests/testthat/testCheckPrintObject.R
@@ -131,18 +131,18 @@ test_that("print rcomp object", {
   # For now we won't hard code each - instead, we will just check a few points...
   
   # We should look for the all match label
-  expect_that(any(textSame == "All compared variables match "),is_true())
-  expect_that(any(textSame == " Number of rows compared: 150 "),is_true())
-  expect_that(any(textSame == " Number of columns compared: 5"),is_true())
+  expect_true(any(textSame == "All compared variables match "),is_true())
+  expect_true(any(textSame == " Number of rows compared: 150 "),is_true())
+  expect_true(any(textSame == " Number of columns compared: 5"),is_true())
   
   # Expect they differ
-  expect_that(textSame[[1]] == textDiff[[1]], is_false())
-  expect_that(textSame[[2]] == textDiff[[2]], is_false())
-  expect_that(textSame[[3]] == textDiff[[3]], is_false())
-  expect_that(textSame[[4]] == textDiff[[4]], is_false())
+  expect_false(textSame[[1]] == textDiff[[1]], is_false())
+  expect_false(textSame[[2]] == textDiff[[2]], is_false())
+  expect_false(textSame[[3]] == textDiff[[3]], is_false())
+  expect_false(textSame[[4]] == textDiff[[4]], is_false())
   
   # Check that the textDiff has more cols
-  expect_that(length(textDiff) > 2,is_true())
+  expect_true(length(textDiff) > 2,is_true())
   
   
 })
@@ -175,10 +175,10 @@ test_that("test print rcompobj rows columns dropped messages", {
   text4 <- capture.output(print(comp4))
   
   # Check we see what we  expect
-  expect_that(any(grepl("All columns were compared, all rows were compared", text1, fixed = TRUE)), is_true())
-  expect_that(any(grepl("All columns were compared, 4 row(s) were dropped from comparison", text2, fixed = TRUE)), is_true())
-  expect_that(any(grepl("1 column(s) were dropped, all rows were compared", text3, fixed = TRUE)), is_true())
-  expect_that(any(grepl("2 column(s) were dropped, 4 row(s) were dropped from comparison", text4, fixed = TRUE)), is_true())
+  expect_true(any(grepl("All columns were compared, all rows were compared", text1, fixed = TRUE)))
+  expect_true(any(grepl("All columns were compared, 4 row(s) were dropped from comparison", text2, fixed = TRUE)))
+  expect_true(any(grepl("1 column(s) were dropped, all rows were compared", text3, fixed = TRUE)))
+  expect_true(any(grepl("2 column(s) were dropped, 4 row(s) were dropped from comparison", text4, fixed = TRUE)))
   
 })
 
@@ -221,20 +221,20 @@ test_that("test print with two empty data frames", {
   text4 <- capture.output(print(comp4))
   
   expect_true(length(text1)==2)
-  expect_that(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text1, fixed = TRUE)), is_true())
-  expect_that(any(grepl("No variables match", text1, fixed = TRUE)), is_true())
+  expect_true(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text1, fixed = TRUE)))
+  expect_true(any(grepl("No variables match", text1, fixed = TRUE)))
   
   expect_true(length(text2)==2)
-  expect_that(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text2, fixed = TRUE)), is_true())
-  expect_that(any(grepl("No variables match", text2, fixed = TRUE)), is_true())
+  expect_true(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text2, fixed = TRUE)))
+  expect_true(any(grepl("No variables match", text2, fixed = TRUE)))
   
   expect_true(length(text3)==2)
-  expect_that(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text3, fixed = TRUE)), is_true())
-  expect_that(any(grepl("No variables match", text3, fixed = TRUE)), is_true())
+  expect_true(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text3, fixed = TRUE)))
+  expect_true(any(grepl("No variables match", text3, fixed = TRUE)))
   
   expect_true(length(text4)==2)
-  expect_that(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text4, fixed = TRUE)), is_true())
-  expect_that(any(grepl("No variables match", text4, fixed = TRUE)), is_true())
+  expect_true(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text4, fixed = TRUE)))
+  expect_true(any(grepl("No variables match", text4, fixed = TRUE)))
   
 })
 
@@ -280,35 +280,35 @@ test_that("test print with one empty data frames", {
   text8 <- capture.output(print(comp8))
   
   expect_true(length(text1)==2)
-  expect_that(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text1, fixed = TRUE)), is_true())
-  expect_that(any(grepl("No variables match", text1, fixed = TRUE)), is_true())
+  expect_true(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text1, fixed = TRUE)))
+  expect_true(any(grepl("No variables match", text1, fixed = TRUE)))
   
   expect_true(length(text2)==2)
-  expect_that(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text2, fixed = TRUE)), is_true())
-  expect_that(any(grepl("No variables match", text2, fixed = TRUE)), is_true())
+  expect_true(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text2, fixed = TRUE)))
+  expect_true(any(grepl("No variables match", text2, fixed = TRUE)))
   
   expect_true(length(text3)==2)
-  expect_that(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text3, fixed = TRUE)), is_true())
-  expect_that(any(grepl("No variables match", text3, fixed = TRUE)), is_true())
+  expect_true(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text3, fixed = TRUE)))
+  expect_true(any(grepl("No variables match", text3, fixed = TRUE)))
   
   expect_true(length(text4)==2)
-  expect_that(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text4, fixed = TRUE)), is_true())
-  expect_that(any(grepl("No variables match", text4, fixed = TRUE)), is_true())
+  expect_true(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text4, fixed = TRUE)))
+  expect_true(any(grepl("No variables match", text4, fixed = TRUE)))
   
   expect_true(length(text5)==2)
-  expect_that(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text5, fixed = TRUE)), is_true())
-  expect_that(any(grepl("No variables match", text5, fixed = TRUE)), is_true())
+  expect_true(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text5, fixed = TRUE)))
+  expect_true(any(grepl("No variables match", text5, fixed = TRUE)))
   
   expect_true(length(text6)==2)
-  expect_that(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text6, fixed = TRUE)), is_true())
-  expect_that(any(grepl("No variables match", text6, fixed = TRUE)), is_true())
+  expect_true(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text6, fixed = TRUE)))
+  expect_true(any(grepl("No variables match", text6, fixed = TRUE)))
   
   expect_true(length(text7)==2)
-  expect_that(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text7, fixed = TRUE)), is_true())
-  expect_that(any(grepl("No variables match", text7, fixed = TRUE)), is_true())
+  expect_true(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text7, fixed = TRUE)))
+  expect_true(any(grepl("No variables match", text7, fixed = TRUE)))
   
   expect_true(length(text8)==2)
-  expect_that(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text8, fixed = TRUE)), is_true())
-  expect_that(any(grepl("No variables match", text8, fixed = TRUE)), is_true())
+  expect_true(any(grepl("All columns were compared,  no rows compared because at least one table has no rows", text8, fixed = TRUE)))
+  expect_true(any(grepl("No variables match", text8, fixed = TRUE)))
   
   })

--- a/dataCompareR/tests/testthat/testEndToEndBit64.R
+++ b/dataCompareR/tests/testthat/testEndToEndBit64.R
@@ -39,12 +39,12 @@ test_that("ComparisonOfBit64Fields", {
     ABcomparison <- rCompare(dfTableA, dfTableB, keys = c("color"))
     ACcomparison <- rCompare(dfTableA, dfTableC, keys = c("color"))
     
-    expect_that(ABcomparison$matches[1] == "BIGNUMBER", is_true() )
-    expect_that(is.na(ACcomparison$matches[1]), is_true() )
+    expect_true(ABcomparison$matches[1] == "BIGNUMBER")
+    expect_true(is.na(ACcomparison$matches[1]))
     
-    expect_that(length(ABcomparison$mismatches) == 0, is_true() )
-    expect_that(nrow(ACcomparison$mismatches$BIGNUMBER) == 5, is_true() )
-    expect_that(all(ACcomparison$mismatches$BIGNUMBER$diffAB == 1), is_true() )
+    expect_true(length(ABcomparison$mismatches) == 0)
+    expect_true(nrow(ACcomparison$mismatches$BIGNUMBER) == 5)
+    expect_true(all(ACcomparison$mismatches$BIGNUMBER$diffAB == 1))
   }
   
  })

--- a/dataCompareR/tests/testthat/testEndToEndDates.R
+++ b/dataCompareR/tests/testthat/testEndToEndDates.R
@@ -34,12 +34,12 @@ test_that("ComparisonOfEqualDates", {
   
   ABcomparison <- rCompare(dfTableA, dfTableB, keys = c("color"))
   
-  expect_that(ABcomparison$matches[1] == "DATEA", is_true())
+  expect_true(ABcomparison$matches[1] == "DATEA")
   
-  expect_that(names(ABcomparison$mismatches)[1] == "DATEB", is_true())
-  expect_that(nrow(ABcomparison$mismatches[[1]]) == 5, is_true())
-  expect_that(all(ABcomparison$mismatches$DATEB$diffAB < 0), is_true())
-  expect_that(all(ABcomparison$mismatches$DATEB$diffAB > -21), is_true())
+  expect_true(names(ABcomparison$mismatches)[1] == "DATEB")
+  expect_true(nrow(ABcomparison$mismatches[[1]]) == 5)
+  expect_true(all(ABcomparison$mismatches$DATEB$diffAB < 0))
+  expect_true(all(ABcomparison$mismatches$DATEB$diffAB > -21))
 
 })
 
@@ -57,12 +57,12 @@ test_that("ComparisonOfPOSIXDates", {
   
   ABcomparison <- rCompare(dfTableA, dfTableB, keys = c("color"))
   
-  expect_that(ABcomparison$matches[1] == "DATEA", is_true())
+  expect_true(ABcomparison$matches[1] == "DATEA")
   
-  expect_that(names(ABcomparison$mismatches)[1] == "DATEB", is_true())
-  expect_that(nrow(ABcomparison$mismatches[[1]]) == 5, is_true())
-  expect_that(all(ABcomparison$mismatches$DATEB$diffAB < 0), is_true())
-  expect_that(all(ABcomparison$mismatches$DATEB$diffAB > -21), is_true())
+  expect_true(names(ABcomparison$mismatches)[1] == "DATEB")
+  expect_true(nrow(ABcomparison$mismatches[[1]]) == 5)
+  expect_true(all(ABcomparison$mismatches$DATEB$diffAB < 0))
+  expect_true(all(ABcomparison$mismatches$DATEB$diffAB > -21))
   
 })
 
@@ -77,25 +77,25 @@ test_that("ComparisonOfMixedDates", {
   dfTableA$dateA <- as.POSIXct.Date(dfTableA$dateA)
   dfTableA$dateB <- as.POSIXct.Date(dfTableA$dateB)
   ABcomparison <- rCompare(dfTableA, dfTableB, keys = c("color"))
-  expect_that(length(ABcomparison$matches) == 0, is_true())
-  expect_that(names(ABcomparison$mismatches)[1] == "DATEA", is_true())
-  expect_that(names(ABcomparison$mismatches)[2] == "DATEB", is_true())
-  expect_that(all(ABcomparison$mismatches$DATEA$diffAB == ""), is_true())
-  expect_that(all(ABcomparison$mismatches$DATEB$diffAB == ""), is_true())
+  expect_true(length(ABcomparison$matches) == 0)
+  expect_true(names(ABcomparison$mismatches)[1] == "DATEA")
+  expect_true(names(ABcomparison$mismatches)[2] == "DATEB")
+  expect_true(all(ABcomparison$mismatches$DATEA$diffAB == ""))
+  expect_true(all(ABcomparison$mismatches$DATEB$diffAB == ""))
   
   # Set the matching column in B to Posix - now A/A should match
   dfTableB$dateA <- as.POSIXct.Date(dfTableB$dateA)
   ABcomparison <- rCompare(dfTableA, dfTableB, keys = c("color"))
-  expect_that(ABcomparison$matches[1] == "DATEA", is_true())
-  expect_that(names(ABcomparison$mismatches)[1] == "DATEB", is_true())
-  expect_that(all(ABcomparison$mismatches$DATEB$diffAB == ""), is_true())
+  expect_true(ABcomparison$matches[1] == "DATEA")
+  expect_true(names(ABcomparison$mismatches)[1] == "DATEB")
+  expect_true(all(ABcomparison$mismatches$DATEB$diffAB == ""))
   
   
   # Change last column - now it musmatches due to differences
   dfTableB$dateB <- as.POSIXct.Date(dfTableB$dateB)
   ABcomparison <- rCompare(dfTableA, dfTableB, keys = c("color"))
-  expect_that(ABcomparison$matches[1] == "DATEA", is_true())
-  expect_that(names(ABcomparison$mismatches)[1] == "DATEB", is_true())
-  expect_that(all(ABcomparison$mismatches$DATEB$diffAB < 0), is_true())
-  expect_that(all(ABcomparison$mismatches$DATEB$diffAB > -21), is_true())
+  expect_true(ABcomparison$matches[1] == "DATEA")
+  expect_true(names(ABcomparison$mismatches)[1] == "DATEB")
+  expect_true(all(ABcomparison$mismatches$DATEB$diffAB < 0))
+  expect_true(all(ABcomparison$mismatches$DATEB$diffAB > -21))
 })

--- a/dataCompareR/tests/testthat/testEndToEndFourKeys.R
+++ b/dataCompareR/tests/testthat/testEndToEndFourKeys.R
@@ -54,7 +54,7 @@ test_that("ComparisonOfEquals", {
   expect_equal(ABcomparison$rowMatching$matchKeys, toupper(c("color", "number", "color2", "number2")))
   
   # Matches should just be 1 field
-  expect_that(ABcomparison$matches == "VALUEA", is_true())
+  expect_true(ABcomparison$matches == "VALUEA")
   
   # Mismatches should be empty
   expect_equal(length(ABcomparison$mismatches), 0)
@@ -138,7 +138,7 @@ test_that("ComparisonOfMissRows", {
   expect_equal(ABcomparison$rowMatching$matchKeys, toupper(c("color", "number", "color2", "number2")))
   
   # Matches should just be 1 field
-  expect_that(ABcomparison$matches == "VALUEA", is_true())
+  expect_true(ABcomparison$matches == "VALUEA")
   
   # Mismatches should be empty
   expect_equal(length(ABcomparison$mismatches), 0)
@@ -179,7 +179,7 @@ test_that("ComparisonOfMissCols", {
   expect_equal(ABcomparison$rowMatching$matchKeys, toupper(c("color", "number", "color2", "number2")))
   
   # Matches should just be 1 field
-  expect_that(ABcomparison$matches == "VALUEA", is_true())
+  expect_true(ABcomparison$matches == "VALUEA")
   
   # Mismatches should be empty
   expect_equal(length(ABcomparison$mismatches), 0)

--- a/dataCompareR/tests/testthat/testEndToEndOrderedFactors.R
+++ b/dataCompareR/tests/testthat/testEndToEndOrderedFactors.R
@@ -33,11 +33,11 @@ test_that("ComparisonOfOrderedFactor", {
   
   ABcomparison <- rCompare(dfTableA, dfTableB, keys = c("color"))
   
-  expect_that(ABcomparison$matches[1] == "COLOR2", is_true())
+  expect_true(ABcomparison$matches[1] == "COLOR2")
   
-  expect_that(names(ABcomparison$mismatches)[1] == "COLOR3", is_true())
-  expect_that(nrow(ABcomparison$mismatches[[1]]) == 4, is_true())
-  expect_that(all(ABcomparison$mismatches$COLOR3$diffAB == ""), is_true())
+  expect_true(names(ABcomparison$mismatches)[1] == "COLOR3")
+  expect_true(nrow(ABcomparison$mismatches[[1]]) == 4)
+  expect_true(all(ABcomparison$mismatches$COLOR3$diffAB == ""))
   
 })
 

--- a/dataCompareR/tests/testthat/testEndToEndTimes.R
+++ b/dataCompareR/tests/testthat/testEndToEndTimes.R
@@ -34,12 +34,12 @@ test_that("ComparisonOfEqualDates", {
   
   ABcomparison <- rCompare(dfTableA, dfTableB, keys = c("color"))
   
-  expect_that(ABcomparison$matches[1] == "DATEA", is_true())
+  expect_true(ABcomparison$matches[1] == "DATEA")
   
-  expect_that(names(ABcomparison$mismatches)[1] == "DATEB", is_true())
-  expect_that(nrow(ABcomparison$mismatches[[1]]) == 5, is_true())
-  expect_that(all(ABcomparison$mismatches$DATEB$diffAB < 0), is_true())
-  expect_that(all(ABcomparison$mismatches$DATEB$diffAB > -21), is_true())
+  expect_true(names(ABcomparison$mismatches)[1] == "DATEB")
+  expect_true(nrow(ABcomparison$mismatches[[1]]) == 5)
+  expect_true(all(ABcomparison$mismatches$DATEB$diffAB < 0))
+  expect_true(all(ABcomparison$mismatches$DATEB$diffAB > -21))
   
 })
 

--- a/dataCompareR/tests/testthat/testEndToEndTitanic.R
+++ b/dataCompareR/tests/testthat/testEndToEndTitanic.R
@@ -112,8 +112,8 @@ test_that("ComparisonOfUnequals", {
     b1a <- rCompare(titanic,titanic2,trimChars = TRUE, keys = 'PassengerId')
     b1b <- rCompare(titanic,titanic2,trimChars = TRUE)
     
-    b2 <- rCompare(titanic,titanic2, keys = 'PassengerId',,trimChars = FALSE)
-    b3 <- rCompare(titanic, titanic2shuffle, , keys = 'PassengerId',trimChars = FALSE)
+    b2 <- rCompare(titanic,titanic2, keys = 'PassengerId',trimChars = FALSE)
+    b3 <- rCompare(titanic, titanic2shuffle, keys = 'PassengerId',trimChars = FALSE)
     b4 <- rCompare(titanic,titanic2DataTable, keys = 'PassengerId',trimChars = FALSE)
     b5 <- rCompare(titanic,titanic2Matrix, keys = 'PassengerId',trimChars = FALSE)
     b6 <- rCompare(titanic,titanic2Tibble, keys = 'PassengerId',trimChars = FALSE)
@@ -148,59 +148,59 @@ test_that("ComparisonOfUnequals", {
     expect_that(b1$rowMatching$inB[[1]], equals(logical(0)) )
     
     # Check that b1 has mismatches - not trimming chars so expect 6 issues
-    expect_that(length(b1$mismatches) >0 , is_true() )
+    expect_true(length(b1$mismatches) >0)
     # 3 fields mismatch
-    expect_that(length(b1$mismatches) == 3 , is_true() )
+    expect_true(length(b1$mismatches) == 3)
     expect_that(names(b1$mismatches)[1], equals("EMBARKED"))
     expect_that(names(b1$mismatches)[2], equals("HASSURVIVED"))
     expect_that(names(b1$mismatches)[3], equals("NAME"))
     
     # EMBARKED should mismatch
     # Should have 6 columns
-    expect_that(length(b1$mismatches$EMBARKED) == 7 , is_true() )
+    expect_true(length(b1$mismatches$EMBARKED) == 7)
     # I am not working this out - assume that 170 is correct and make sure it holds later
-    expect_that(length(b1$mismatches$EMBARKED[[1]]) == 170 , is_true() )
+    expect_true(length(b1$mismatches$EMBARKED[[1]]) == 170)
     
     # CABIN should not have mismatches
     expect_that(which(names(b1$mismatches) == 'CABIN'),equals(integer(0)) )
     
     # HasSurvived should have 1 mismatch
     # but first, it should have 6 columns
-    expect_that(length(b1$mismatches$HASSURVIVED) == 7 , is_true() )
+    expect_true(length(b1$mismatches$HASSURVIVED) == 7)
     # and 1 row
-    expect_that(length(b1$mismatches$HASSURVIVED[[1]]) == 1 , is_true() )
+    expect_true(length(b1$mismatches$HASSURVIVED[[1]]) == 1)
     # And they're NAN and NA
-    expect_that(is.na(b1$mismatches$HASSURVIVED$valueA[1]) , is_true() )
-    expect_that(as.character(b1$mismatches$HASSURVIVED$valueB[1]) == "NaN", is_true() )
+    expect_true(is.na(b1$mismatches$HASSURVIVED$valueA[1]))
+    expect_true(as.character(b1$mismatches$HASSURVIVED$valueB[1]) == "NaN")
     
     # NAME should have 9 rows of mismatches
     # And of course, 6 cols
-    expect_that(length(b1$mismatches$NAME) == 7 , is_true() )
-    expect_that(length(b1$mismatches$NAME[[1]]) == 9 , is_true() )
+    expect_true(length(b1$mismatches$NAME) == 7)
+    expect_true(length(b1$mismatches$NAME[[1]]) == 9)
     
     # b1a should be the same, apart from the mismatches, which should only reveal 6 in total
-    expect_that(all.equal(b1$matches,b1a$matches),is_true())
-    expect_that(all.equal(b1$rowMatching,b1a$rowMatching),is_true())
-    expect_that(all.equal(b1$colMatching,b1a$colMatching),is_true())
-    expect_that(all.equal(b1$cleaninginfo,b1a$cleaninginfo),is_true())
+    expect_true(all.equal(b1$matches,b1a$matches))
+    expect_true(all.equal(b1$rowMatching,b1a$rowMatching))
+    expect_true(all.equal(b1$colMatching,b1a$colMatching))
+    expect_true(all.equal(b1$cleaninginfo,b1a$cleaninginfo))
     
-    expect_that(all.equal(b1$mismatches$EMBARKED,b1a$mismatches$EMBARKED),is_true())
-    expect_that(all.equal(b1$mismatches$HASSURVIVED,b1a$mismatches$HASSURVIVED),is_true())
-    expect_that(all.equal(b1$mismatches$CABIN,b1a$mismatches$CABIN),is_true())
-    expect_that(length(b1$mismatches$NAME[[1]]) == length(b1a$mismatches$NAME[[1]]),is_false())
-    expect_that(length(b1a$mismatches$NAME[[1]]) == 6,is_true())
+    expect_true(all.equal(b1$mismatches$EMBARKED,b1a$mismatches$EMBARKED))
+    expect_true(all.equal(b1$mismatches$HASSURVIVED,b1a$mismatches$HASSURVIVED))
+    expect_true(all.equal(b1$mismatches$CABIN,b1a$mismatches$CABIN))
+    expect_false(length(b1$mismatches$NAME[[1]]) == length(b1a$mismatches$NAME[[1]]))
+    expect_true(length(b1a$mismatches$NAME[[1]]) == 6)
     
     
     # b1b should match b1a in terms of content, but differs in format, so check it finds same number of name changes
-    expect_that(all.equal(b1b$colMatching,b1a$colMatching),is_true())
-    expect_that(all.equal(b1b$cleaninginfo,b1a$cleaninginfo),is_true())
-    expect_that(length(b1b$mismatches$NAME[[1]]) == 6,is_true())
+    expect_true(all.equal(b1b$colMatching,b1a$colMatching))
+    expect_true(all.equal(b1b$cleaninginfo,b1a$cleaninginfo))
+    expect_true(length(b1b$mismatches$NAME[[1]]) == 6)
     
     
     # 1 diff, due to lack of a match key
-    expect_that(length(b1b$matches)- length(b1a$matches) == 1, is_true())
-    expect_that(length(b1b$rowMatching$inboth) == length(b1a$rowMatching$inboth$PASSENGERID),is_true())
-    expect_that(length(b1b$mismatches) == length(b1a$mismatches),is_true())
+    expect_true(length(b1b$matches)- length(b1a$matches) == 1)
+    expect_true(length(b1b$rowMatching$inboth) == length(b1a$rowMatching$inboth$PASSENGERID))
+    expect_true(length(b1b$mismatches) == length(b1a$mismatches))
     
       # Part 2 - determine that b2-b6 match b1 as far as expected
   
@@ -270,17 +270,17 @@ test_that("ComparisonWithMissingRows", {
     
     
     # Row matching - expect to miss out on 91 rows
-    expect_that(length(c1$rowMatching$inboth$PASSENGERID) == 800, is_true())
-    expect_that(length(c1$rowMatching$inA$PASSENGERID) == 91, is_true())
-    expect_that(length(c1$rowMatching$inB$PASSENGERID) == 0, is_true())
+    expect_true(length(c1$rowMatching$inboth$PASSENGERID) == 800)
+    expect_true(length(c1$rowMatching$inA$PASSENGERID) == 91)
+    expect_true(length(c1$rowMatching$inB$PASSENGERID) == 0)
     
-    expect_that(length(c2$rowMatching$inboth$PASSENGERID) == 800, is_true())
-    expect_that(length(c2$rowMatching$inA$PASSENGERID) == 91, is_true())
-    expect_that(length(c2$rowMatching$inB$PASSENGERID) == 0, is_true())
+    expect_true(length(c2$rowMatching$inboth$PASSENGERID) == 800)
+    expect_true(length(c2$rowMatching$inA$PASSENGERID) == 91)
+    expect_true(length(c2$rowMatching$inB$PASSENGERID) == 0)
     
-    expect_that(length(c3$rowMatching$inboth$PASSENGERID) == 800, is_true())
-    expect_that(length(c3$rowMatching$inA$PASSENGERID) == 0, is_true())
-    expect_that(length(c3$rowMatching$inB$PASSENGERID) == 91, is_true())
+    expect_true(length(c3$rowMatching$inboth$PASSENGERID) == 800)
+    expect_true(length(c3$rowMatching$inA$PASSENGERID) == 0)
+    expect_true(length(c3$rowMatching$inB$PASSENGERID) == 91)
     
     # Can't do much about if the mismatches work, but, we can check equality where we can
     # Col matching should be the same

--- a/dataCompareR/tests/testthat/testEndToEndTwoKeys.R
+++ b/dataCompareR/tests/testthat/testEndToEndTwoKeys.R
@@ -50,7 +50,7 @@ test_that("ComparisonOfEquals", {
   expect_equal(ABcomparison$rowMatching$matchKeys, c("COLOR","NUMBER"))
   
   # Matches should just be 1 field
-  expect_that(ABcomparison$matches == "VALUEA", is_true())
+  expect_true(ABcomparison$matches == "VALUEA")
   
   # Mismatches should be empty
   expect_equal(length(ABcomparison$mismatches), 0)
@@ -126,7 +126,7 @@ test_that("ComparisonOfMissRows", {
   expect_equal(ABcomparison$rowMatching$inB$NUMBER, logical(0))
   
   # Matches should just be 1 field
-  expect_that(ABcomparison$matches == "VALUEA", is_true())
+  expect_true(ABcomparison$matches == "VALUEA")
   
   # Mismatches should be empty
   expect_equal(length(ABcomparison$mismatches), 0)
@@ -163,7 +163,7 @@ test_that("ComparisonOfMissCols", {
   expect_equal(ABcomparison$rowMatching$matchKeys, c("COLOR","NUMBER"))
   
   # Matches should just be 1 field
-  expect_that(ABcomparison$matches == "VALUEA", is_true())
+  expect_true(ABcomparison$matches == "VALUEA")
   
   # Mismatches should be empty
   expect_equal(length(ABcomparison$mismatches), 0)

--- a/dataCompareR/tests/testthat/test_outHelperFunctions.R
+++ b/dataCompareR/tests/testthat/test_outHelperFunctions.R
@@ -26,8 +26,8 @@ context('out_helperFunctions.R')
 
 test_that("isNotNull", {
 
-  expect_that(isNotNull(NULL), is_false())
-  expect_that(isNotNull(1), is_true())
+  expect_false(isNotNull(NULL))
+  expect_true(isNotNull(1))
   
 })
 

--- a/dataCompareR/tests/testthat/testcreateReportText.R
+++ b/dataCompareR/tests/testthat/testcreateReportText.R
@@ -39,49 +39,49 @@ test_that("check a non comprehensive set of properties about createReportText", 
   # For now we won't hard code each - instead, we will just check a few points...
   
   # We should look for the names of the data
-  expect_that(any(grepl("iris",textSame)),is_true())
-  expect_that(any(grepl("iris",textDiff)),is_true())
-  expect_that(any(grepl("iris2",textSame)),is_false())
-  expect_that(any(grepl("iris2",textDiff)),is_true())
+  expect_true(any(grepl("iris",textSame)))
+  expect_true(any(grepl("iris",textDiff)))
+  expect_false(any(grepl("iris2",textSame)))
+  expect_true(any(grepl("iris2",textDiff)))
   
   # Check that the column equal report is working
-  expect_that(any(grepl("Columns with all rows equal : PETAL.LENGTH, PETAL.WIDTH, SEPAL.LENGTH, SEPAL.WIDTH, SPECIES",textSame)),is_true())
-  expect_that(any(grepl("Columns with all rows equal : PETAL.LENGTH, PETAL.WIDTH, SEPAL.LENGTH, SEPAL.WIDTH, SPECIES",textDiff)),is_true())
+  expect_true(any(grepl("Columns with all rows equal : PETAL.LENGTH, PETAL.WIDTH, SEPAL.LENGTH, SEPAL.WIDTH, SPECIES",textSame)))
+  expect_true(any(grepl("Columns with all rows equal : PETAL.LENGTH, PETAL.WIDTH, SEPAL.LENGTH, SEPAL.WIDTH, SPECIES",textDiff)))
   
   # Expect the diff report to contain 140 (10 rows are missing) and 10
-  expect_that(any(grepl("140",textDiff)),is_true())
-  expect_that(any(grepl("10",textDiff)),is_true())
+  expect_true(any(grepl("140",textDiff)))
+  expect_true(any(grepl("10",textDiff)))
   
   # And both contain 150
-  expect_that(any(grepl("150",textSame)),is_true())
-  expect_that(any(grepl("150",textDiff)),is_true())
+  expect_true(any(grepl("150",textSame)))
+  expect_true(any(grepl("150",textDiff)))
   
   # Both contain some data, say more than 40 lines
-  expect_that(length(textSame) > 40,is_true())
-  expect_that(length(textDiff) > 40,is_true())
+  expect_true(length(textSame) > 40)
+  expect_true(length(textDiff) > 40)
   
   # Expect a bunch of words will always be there
-  expect_that(any(grepl("columns",textDiff)),is_true())
-  expect_that(any(grepl("columns",textSame)),is_true())
+  expect_true(any(grepl("columns",textDiff)))
+  expect_true(any(grepl("columns",textSame)))
   
-  expect_that(any(grepl("rows",textDiff)),is_true())
-  expect_that(any(grepl("rows",textSame)),is_true())
+  expect_true(any(grepl("rows",textDiff)))
+  expect_true(any(grepl("rows",textSame)))
   
-  expect_that(any(grepl("Variable",textDiff)),is_true())
-  expect_that(any(grepl("Variable",textSame)),is_true())
+  expect_true(any(grepl("Variable",textDiff)))
+  expect_true(any(grepl("Variable",textSame)))
   
-  expect_that(any(grepl("equal",textDiff)),is_true())
-  expect_that(any(grepl("equal",textSame)),is_true())
+  expect_true(any(grepl("equal",textDiff)))
+  expect_true(any(grepl("equal",textSame)))
   
-  expect_that(any(grepl("unequal",textDiff)),is_true())
-  expect_that(any(grepl("unequal",textSame)),is_true())
+  expect_true(any(grepl("unequal",textDiff)))
+  expect_true(any(grepl("unequal",textSame)))
   
   # Expect they differ
-  expect_that(all(textDiff==textSame),is_false())
+  expect_false(all(textDiff==textSame))
 
   # Expect that both contain the line "No match key used, comparison is by row"
-  expect_that(any(grepl("No match key used, comparison is by row",textDiff)),is_true())
-  expect_that(any(grepl("No match key used, comparison is by row",textSame)),is_true())
+  expect_true(any(grepl("No match key used, comparison is by row",textDiff)))
+  expect_true(any(grepl("No match key used, comparison is by row",textSame)))
   
 })
 
@@ -99,12 +99,12 @@ test_that("check a key based match with 1 matching keys", {
   textKeys<- capture.output(createReportText(summary.dataCompareRobject(testKeys)))
   
   
-  expect_that(length(textKeys) != length(textNoKeys), is_true())
-  expect_that(any(grepl("No rows were compared, so no summary can be provided",textKeys)),is_true())
+  expect_true(length(textKeys) != length(textNoKeys), is_true())
+  expect_true(any(grepl("No rows were compared, so no summary can be provided",textKeys)))
   
   # Expect that the match keys are present in the output
-  expect_that(any(grepl("No match key used, comparison is by row",textNoKeys)),is_true())
-  expect_that(any(grepl("Match keys : 1   - TEMPERATURE",textKeys, fixed = TRUE)),is_true())
+  expect_true(any(grepl("No match key used, comparison is by row",textNoKeys)))
+  expect_true(any(grepl("Match keys : 1   - TEMPERATURE",textKeys, fixed = TRUE)))
   
 })
 


### PR DESCRIPTION
## Description
I have gone through all the tests and updated the testthat code due to deprecated code.

## Motivation and Context
My motivation is because I like this package a lot and it will be good to get it back onto CRAN.
Fixes issue Unit tests throw warnings due to testthat changes #72

## How Has This Been Tested?
I ran each of the testthat files and make commit changes to each one where I made changes. All ran with only a few warnings around packages and when they were built.
I also added the library(titanic) to get the titanic data to run.
This should not affect any other code.

## Screenshots (if appropriate):

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
