### PR TITLE
Fixes single column dataframe

### DIFF
--- a/dataCompareR/R/pd_matchRows.R
+++ b/dataCompareR/R/pd_matchRows.R
@@ -164,9 +164,9 @@ matchNoIndex <- function(df_a, df_b)
   if(nrow(df_a)>nrow(df_b)) {
     
     if(nrow(df_b)==0) {
-      df_a_subset <- df_a[0,]
+      df_a_subset <- df_a[0, , drop=FALSE]
     } else {
-      df_a_subset <- df_a[1:nrow(df_b),]
+      df_a_subset <- df_a[1:nrow(df_b), , drop=FALSE]
     }
     
     df_b_subset <- df_b
@@ -177,9 +177,9 @@ matchNoIndex <- function(df_a, df_b)
     df_a_subset <- df_a
     
     if(nrow(df_a)==0) {
-      df_b_subset <-df_b[0,]
+      df_b_subset <-df_b[0, , drop=FALSE]
     } else {
-      df_b_subset <-df_b[1:nrow(df_a),]
+      df_b_subset <-df_b[1:nrow(df_a), , drop=FALSE]
     }
     
     rows_dropped_from_a <- data.frame(indices_removed=integer())

--- a/dataCompareR/tests/testthat/testEndToEnd1ColFrames.R
+++ b/dataCompareR/tests/testthat/testEndToEnd1ColFrames.R
@@ -1,0 +1,98 @@
+# SPDX-Copyright: Copyright (c) Capital One Services, LLC 
+# SPDX-License-Identifier: Apache-2.0 
+# Copyright 2017 Capital One Services, LLC 
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); 
+# you may not use this file except in compliance with the License. 
+#
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+#
+# Unless required by applicable law or agreed to in writing, software distributed 
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied.
+
+#
+# SYSTEM TEST: dataCompareR : Single column datasets
+#
+# End-to-end system tests of the dataCompareR function that look at 
+# different scenarios involving data frames with a single columns. Added
+# becase there was a bug with single column data frames
+#
+
+library(testthat)
+
+context("Tests dataframes with a single column")
+
+test_that("Comparison with missing row", {
+  
+  df1 <- tibble(col1 = c("cat", "dog", "rat"))
+  df2 <- tibble(col1 = c("cat", "dog", "mouse", "fly"))
+  
+  # test it both ways as we have some logic where nrows a > b, etc
+  comparison1 <- rCompare(df1, df2)
+  comparison2 <- rCompare(df2, df1)
+  
+  # Expect col summary to match the following
+  expect_equal(length(comparison1$colMatching$inboth),1)
+  expect_equal(comparison1$colMatching$inboth, c("COL1"))
+  expect_equal(comparison1$colMatching$inA, character(0))
+  expect_equal(comparison1$colMatching$inB, character(0))
+  
+  expect_equal(length(comparison2$colMatching$inboth),1)
+  expect_equal(comparison2$colMatching$inboth, c("COL1"))
+  expect_equal(comparison2$colMatching$inA, character(0))
+  expect_equal(comparison2$colMatching$inB, character(0))
+  
+  # Expect row summary to match the following
+  expect_equal(length(comparison1$rowMatching),4)
+  expect_equal(comparison1$rowMatching$inboth, c(1,2,3))
+  expect_equal(comparison1$rowMatching$inA$indices_removed, integer(0))
+  expect_equal(comparison1$rowMatching$inB$indices_removed, c(4))
+  
+  expect_equal(length(comparison2$rowMatching),4)
+  expect_equal(comparison2$rowMatching$inboth, c(1,2,3))
+  expect_equal(comparison2$rowMatching$inB$indices_removed, integer(0))
+  expect_equal(comparison2$rowMatching$inA$indices_removed, c(4))
+  
+  # Matches should be empty
+  expect_equal(length(comparison1$matches), 0)
+  expect_equal(length(comparison2$matches), 0)
+  
+  # Mismatches should list with 1 entry
+  expect_equal(length(comparison1$mismatches), 1)
+  expect_equal(names(comparison1$mismatches), c("COL1"))
+  
+  expect_equal(length(comparison2$mismatches), 1)
+  expect_equal(names(comparison2$mismatches), c("COL1"))
+  
+})
+
+
+test_that("Comparison with equal datasets", {
+  
+  df2 <- tibble(col1 = c("cat", "dog", "mouse", "fly"))
+  df1 <- tibble(col1 = c("cat", "dog", "mouse", "fly"))
+  
+  comparison <- rCompare(df1, df2)
+  
+  # Expect col summary to match the following
+  expect_equal(length(comparison$colMatching$inboth),1)
+  expect_equal(comparison$colMatching$inboth, c("COL1"))
+  expect_equal(comparison$colMatching$inA, character(0))
+  expect_equal(comparison$colMatching$inB, character(0))
+  
+  # Expect row summary to match the following
+  expect_equal(length(comparison$rowMatching),4)
+  expect_equal(comparison$rowMatching$inboth, c(1,2,3, 4))
+  expect_equal(comparison$rowMatching$inA$indices_removed, integer(0))
+  expect_equal(comparison$rowMatching$inB$indices_removed, integer(0))
+  
+  # Matches should be empty
+  expect_equal(length(comparison$matches), 1)
+  
+  # Mismatches should list with 1 entry
+  expect_equal(length(comparison$mismatches), 0)
+  
+  
+})
+


### PR DESCRIPTION
## Description

Fixes #71, where the `rCompare` function would error if a single column dataframe was passed. 

This was caused by the way R handles filtering dataframes with a single column. `df[1:2, ]` returns a dataframe if `df` has 2+ columns but returns a vector if `df` has 1 column.

This behaviour can be changed by passing `drop=TRUE` (see https://stackoverflow.com/questions/21025609/how-do-i-extract-a-single-column-from-a-data-frame-as-a-data-frame)

## Motivation and Context
Fixes #71 reported by an external user

## How Has This Been Tested?
- added a new end to end test that checks that the whole dataCompareR flow works for single column dataframes 
- did not amend the tests for the modified `matchNoIndex` function because those tests look like they could use a refactor/tidy up anyway - I can go back and do this if needed?

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [X] All new and existing tests passed.

Tests throw existing warnings around `testthat` . Travis isn't happy, but that appears to be due to #76 .
