### PR TITLE
Cleaned up some test warnings and output

### DIFF
--- a/dataCompareR/DESCRIPTION
+++ b/dataCompareR/DESCRIPTION
@@ -1,8 +1,9 @@
 Package: dataCompareR
 Title: Compare Two Data Frames and Summarise the Difference
 Version: 0.1.2
-Authors@R: c(person("Rob", "Noble-Eddy", email = "opensource@capitalone.com", role = c("aut", "cre")),
-           person("Sarah", "Johnston", role = c("aut")),
+Authors@R: c(
+           person("Sarah", "Johnston",  email = "opensource@capitalone.com",  role = c("aut", "cre")),
+           person("Rob", "Noble-Eddy", role = c("aut")),
            person("Sarah", "Pollicott", role = c("aut")),
            person("Merlijn", "van Horssen", role = c("aut")),
            person("Lukas", "Drapal", role = c("ctb")),

--- a/dataCompareR/tests/testthat/testCheckPrintObject.R
+++ b/dataCompareR/tests/testthat/testCheckPrintObject.R
@@ -30,7 +30,7 @@ if(require(titanic)) {
   
   source('createTitanicDatasets.R')
 
-  test_that("comparePrintEqual", {
+  test_that("print only generates message when data sets match", {
     
     
     # The object has already pre-determined structure
@@ -39,11 +39,11 @@ if(require(titanic)) {
     
     # Check the print output with different parameters
     
-    p0 <- print(compareObject)
-    p1 <- print(compareObject,nObs = 1)
-    p2 <- print(compareObject,nObs = 2, nVars = 1)
-    p3 <- print(compareObject,verbose = TRUE)
-    p4 <- print(compareObject,nObs = 2, nVars = 1,verbose = TRUE)
+    expect_output(p0 <- print(compareObject))
+    expect_output(p1 <- print(compareObject,nObs = 1))
+    expect_output(p2 <- print(compareObject,nObs = 2, nVars = 1))
+    expect_output(p3 <- print(compareObject,verbose = TRUE))
+    expect_output(p4 <- print(compareObject,nObs = 2, nVars = 1,verbose = TRUE))
     
     
     expect_null(p0, info = "Expect a NULL object to be created and a message sent to the console 'All variables match'")
@@ -54,7 +54,7 @@ if(require(titanic)) {
     
   })
   
-  test_that("comparePrintUnEqual", {
+  test_that("print returns message and data when mismatches occur", {
     
     
     # The object has already pre-determined structure
@@ -63,11 +63,11 @@ if(require(titanic)) {
    
     #Generate print output objects
     
-    p0 <- print(b1)
-    p1 <- print(b1,nObs = 1)
-    p2 <- print(b1,nObs = 2, nVars = 1)
-    p3 <- print(b1,verbose = TRUE)
-    p4 <- print(b1,nObs = 2, nVars = 1,verbose = TRUE)
+    expect_output(p0 <- print(b1))
+    expect_output(p1 <- print(b1,nObs = 1))
+    expect_output(p2 <- print(b1,nObs = 2, nVars = 1))
+    expect_output(p3 <- print(b1,verbose = TRUE))
+    expect_output(p4 <- print(b1,nObs = 2, nVars = 1,verbose = TRUE))
     
     #Test output is as expected:
     
@@ -131,18 +131,18 @@ test_that("print rcomp object", {
   # For now we won't hard code each - instead, we will just check a few points...
   
   # We should look for the all match label
-  expect_true(any(textSame == "All compared variables match "),is_true())
-  expect_true(any(textSame == " Number of rows compared: 150 "),is_true())
-  expect_true(any(textSame == " Number of columns compared: 5"),is_true())
+  expect_true(any(textSame == "All compared variables match "))
+  expect_true(any(textSame == " Number of rows compared: 150 "))
+  expect_true(any(textSame == " Number of columns compared: 5"))
   
   # Expect they differ
-  expect_false(textSame[[1]] == textDiff[[1]], is_false())
-  expect_false(textSame[[2]] == textDiff[[2]], is_false())
-  expect_false(textSame[[3]] == textDiff[[3]], is_false())
-  expect_false(textSame[[4]] == textDiff[[4]], is_false())
+  expect_false(textSame[[1]] == textDiff[[1]])
+  expect_false(textSame[[2]] == textDiff[[2]])
+  expect_false(textSame[[3]] == textDiff[[3]])
+  expect_false(textSame[[4]] == textDiff[[4]])
   
   # Check that the textDiff has more cols
-  expect_true(length(textDiff) > 2,is_true())
+  expect_true(length(textDiff) > 2)
   
   
 })

--- a/dataCompareR/tests/testthat/testMakeValidNames.R
+++ b/dataCompareR/tests/testthat/testMakeValidNames.R
@@ -97,9 +97,6 @@ test_that("makeValidNames function in end to end context", {
   names(iris2) <- c("`__a horrible name`", "`and   another`", "`___so so bad`", "and111", "a_good_one")
   names(iris3) <- c("A", "A", "A", "A", "A")
   
-  print(summary(iris))
-  print(summary(iris2))
-  
   expect_message(a <- rCompare(iris, iris2), "Fixing syntactically invalid names")
   expect_message(b <- rCompare(iris2, iris2), "Fixing syntactically invalid names")
   

--- a/dataCompareR/tests/testthat/testPrintSummaryRcompareObject.R
+++ b/dataCompareR/tests/testthat/testPrintSummaryRcompareObject.R
@@ -41,45 +41,45 @@ test_that("test printsummaryrcompobj", {
   # For now we won't hard code each - instead, we will just check a few points...
   
   # We should look for the names of the data
-  expect_that(any(grepl("iris",textSame)),is_true())
-  expect_that(any(grepl("iris",textDiff)),is_true())
-  expect_that(any(grepl("iris2",textSame)),is_false())
-  expect_that(any(grepl("iris2",textDiff)),is_true())
+  expect_true(any(grepl("iris",textSame)))
+  expect_true(any(grepl("iris",textDiff)))
+  expect_false(any(grepl("iris2",textSame)))
+  expect_true(any(grepl("iris2",textDiff)))
   
   # Check that the column equal report is working
-  expect_that(any(grepl("Columns with all rows equal : PETAL.LENGTH, PETAL.WIDTH, SEPAL.LENGTH, SEPAL.WIDTH, SPECIES",textSame)),is_true())
-  expect_that(any(grepl("Columns with all rows equal : PETAL.LENGTH, PETAL.WIDTH, SEPAL.LENGTH, SEPAL.WIDTH, SPECIES",textDiff)),is_true())
+  expect_true(any(grepl("Columns with all rows equal : PETAL.LENGTH, PETAL.WIDTH, SEPAL.LENGTH, SEPAL.WIDTH, SPECIES",textSame)))
+  expect_true(any(grepl("Columns with all rows equal : PETAL.LENGTH, PETAL.WIDTH, SEPAL.LENGTH, SEPAL.WIDTH, SPECIES",textDiff)))
   
   # Expect the diff report to contain 140 (10 rows are missing) and 10
-  expect_that(any(grepl("140",textDiff)),is_true())
-  expect_that(any(grepl("10",textDiff)),is_true())
+  expect_true(any(grepl("140",textDiff)))
+  expect_true(any(grepl("10",textDiff)))
   
   # And both contain 150
-  expect_that(any(grepl("150",textSame)),is_true())
-  expect_that(any(grepl("150",textDiff)),is_true())
+  expect_true(any(grepl("150",textSame)))
+  expect_true(any(grepl("150",textDiff)))
   
   # Both contain some data, say more than 40 lines
-  expect_that(length(textSame) > 40,is_true())
-  expect_that(length(textDiff) > 40,is_true())
+  expect_true(length(textSame) > 40)
+  expect_true(length(textDiff) > 40)
   
   # Expect a bunch of words will always be there
-  expect_that(any(grepl("columns",textDiff)),is_true())
-  expect_that(any(grepl("columns",textSame)),is_true())
+  expect_true(any(grepl("columns",textDiff)))
+  expect_true(any(grepl("columns",textSame)))
   
-  expect_that(any(grepl("rows",textDiff)),is_true())
-  expect_that(any(grepl("rows",textSame)),is_true())
+  expect_true(any(grepl("rows",textDiff)))
+  expect_true(any(grepl("rows",textSame)))
   
-  expect_that(any(grepl("Variable",textDiff)),is_true())
-  expect_that(any(grepl("Variable",textSame)),is_true())
+  expect_true(any(grepl("Variable",textDiff)))
+  expect_true(any(grepl("Variable",textSame)))
   
-  expect_that(any(grepl("equal",textDiff)),is_true())
-  expect_that(any(grepl("equal",textSame)),is_true())
+  expect_true(any(grepl("equal",textDiff)))
+  expect_true(any(grepl("equal",textSame)))
   
-  expect_that(any(grepl("unequal",textDiff)),is_true())
-  expect_that(any(grepl("unequal",textSame)),is_true())
+  expect_true(any(grepl("unequal",textDiff)))
+  expect_true(any(grepl("unequal",textSame)))
   
   # Expect they differ
-  expect_that(all(textDiff==textSame),is_false())
+  expect_false(all(textDiff==textSame))
   
 })
 

--- a/dataCompareR/tests/testthat/testSaveReport.R
+++ b/dataCompareR/tests/testthat/testSaveReport.R
@@ -54,13 +54,13 @@ test_that("checks save report works", {
   expect_true(!file.exists(file.path(tmpDir, "testing3.html")))
   
   # Check no errors
-  expect_error(saveReport(aaa, 'testing',reportLocation = '.', HTMLReport = TRUE), NA)
-  expect_error(saveReport(aaa, 'testing', reportLocation = '.',HTMLReport = FALSE), NA)
-  expect_error(saveReport(aaa,  'testing',reportLocation = '.', HTMLReport = TRUE, showInViewer = FALSE), NA)
-  expect_error(saveReport(aaa,  'testing',reportLocation = '.', HTMLReport = FALSE, showInViewer = FALSE), NA)
-  expect_error(saveReport(aaa, 'testing',reportLocation = '.', HTMLReport = TRUE, showInViewer = TRUE), NA)
-  expect_error(saveReport(aaa, 'testing',reportLocation = '.', HTMLReport = FALSE, showInViewer = TRUE), NA)
-   
+  expect_message(saveReport(aaa, 'testing',reportLocation = tmpDir, HTMLReport = TRUE))
+  expect_message(saveReport(aaa, 'testing', reportLocation = tmpDir,HTMLReport = FALSE))
+  expect_message(saveReport(aaa,  'testing',reportLocation = tmpDir, HTMLReport = TRUE, showInViewer = FALSE))
+  expect_message(saveReport(aaa,  'testing',reportLocation = tmpDir, HTMLReport = FALSE, showInViewer = FALSE))
+  expect_message(saveReport(aaa, 'testing',reportLocation = tmpDir, HTMLReport = TRUE, showInViewer = TRUE))
+  expect_message(saveReport(aaa, 'testing',reportLocation = tmpDir, HTMLReport = FALSE, showInViewer = TRUE))
+
 })
 
 

--- a/dataCompareR/tests/testthat/testcreateReportText.R
+++ b/dataCompareR/tests/testthat/testcreateReportText.R
@@ -99,7 +99,7 @@ test_that("check a key based match with 1 matching keys", {
   textKeys<- capture.output(createReportText(summary.dataCompareRobject(testKeys)))
   
   
-  expect_true(length(textKeys) != length(textNoKeys), is_true())
+  expect_true(length(textKeys) != length(textNoKeys))
   expect_true(any(grepl("No rows were compared, so no summary can be provided",textKeys)))
   
   # Expect that the match keys are present in the output


### PR DESCRIPTION

## Description
This cleans up some of the test output, including warnings that were still occurring, as well as some other console output. I also updated the DESCRIPTION to list me as the maintainer (`"cre"`) and changed some confusing descriptions and assertions in the tests that I happened to notice when doing the other work. 

Fixes #72 

## Motivation and Context
The warnings were potentially causing problems related to the package no longer being available on the CRAN. They were also related to the fact that a dependency had deprecated code that we were using. 

## How Has This Been Tested?
The changes I made were related to the `testthat` tests, so I've ran all of the `testthat` tests in my local environment (Windows 10, R 3.6.3). They all pass and there are no more warnings. There is still some console output, but this is part of a test that is skipped on CRAN checks. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
