### PR TITLE
Update CODEOWNERS to point at admin team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,2 @@
 
-# Currently sharing all of the files together
-* @sajohnston @robne1982
+* @capitalone/dataCompareR-admin-team


### PR DESCRIPTION
The new guidance is to have the CodeOwners file point at a project admin team rather than hardcoded usernames.